### PR TITLE
feat(dockerize): implement best practices

### DIFF
--- a/assets/.dockerignore
+++ b/assets/.dockerignore
@@ -1,0 +1,15 @@
+.env*
+.eslint*
+.git
+.husky
+.nvmrc
+.prettier*
+.vscode
+coverage
+coverage-e2e
+dist
+docker-compose*
+Dockerfile
+node_modules
+README.md
+test

--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -1,16 +1,77 @@
-ARG exposed_port=3000
+#
+# Create an intermediate image to build the application that will have devDependencies
+#
+FROM node:18-alpine as builder
 
-FROM node:16
+# Update OS packages
+RUN apk update && apk upgrade --no-cache
 
-# Create app directory
+# Create a directory under the node user
+RUN mkdir /app && chown node:node /app
+
+# Set the working directory
+WORKDIR /app
+
+# Switch to the predefined node use to avoid running as root
+USER node
+
+# Copy both package.json and package-lock.json
+COPY --chown=node:node package*.json ./
+
+# Run clean install
+RUN npm ci \
+  # skip vulnerability check
+  --no-audit \
+  # skip funding messages
+  --fund false \
+  # skip pre/post scripts
+  --ignore-scripts \
+  # skip update information
+  --no-update-notifier
+
+# Copy the source code
+COPY --chown=node:node . /app
+
+# Build the app
+RUN npm run build
+
+#
+# This will be the image used in production with just the build and prod dependencies
+#
+FROM node:18-alpine
+
+# Update OS packages
+RUN apk update && apk upgrade --no-cache
+
+# Create a directory under the node user
+RUN mkdir -p /usr/src/app && chown node:node /usr/src/app
+
+# Set the working directory
 WORKDIR /usr/src/app
 
-# Install app dependencies
-COPY package*.json ./
-RUN npm install --omit=dev --ignore-scripts
+# Switch to the predefined node use to avoid running as root
+USER node
 
-# Bundle app source
-COPY . .
+# Copy both package.json and package-lock.json from the builder image
+COPY --from=builder --chown=node:node /app/package*.json ./
 
-EXPOSE ${exposed_port}
+# Run clean install
+RUN npm ci \
+  # skip dev dependencies
+  --omit=dev \
+  # skip vulnerability check
+  --no-audit \
+  # skip funding messages
+  --fund false \
+  # skip pre/post scripts
+  --ignore-scripts \
+  # skip update information
+  --no-update-notifier \
+  # attempt to reduce image size
+  && npm cache clean --force
+
+# Copy the build from the builder image
+COPY --from=builder --chown=node:node /app/dist/ ./dist/
+
+# Run
 CMD [ "node", "./src/index.js" ]

--- a/src/extensions/dockerize-workflow.js
+++ b/src/extensions/dockerize-workflow.js
@@ -7,6 +7,7 @@ module.exports = (toolbox) => {
     workflowsFolder,
     projectLanguage,
     framework,
+    pkgJsonScripts,
   }) => {
     const {
       filesystem: { copyAsync },
@@ -22,6 +23,7 @@ module.exports = (toolbox) => {
           copyAsync(`${assetsPath}/.project-npmignr`, `${appDir}/.npmignore`),
           copyAsync(`${assetsPath}/scripts/`, `${appDir}/scripts/`),
           copyAsync(`${assetsPath}/Dockerfile`, `${appDir}/Dockerfile`),
+          copyAsync(`${assetsPath}/.dockerignore`, `${appDir}/.dockerignore`),
           copyAsync(
             `${assetsPath}/.github/workflows/dockerize.yaml`,
             `${workflowsFolder}/dockerize.yaml`
@@ -71,6 +73,17 @@ module.exports = (toolbox) => {
       );
     }
 
-    return { asyncOperations };
+    function syncOperations() {
+      pkgJsonScripts.push({
+        'image:build': `DOCKER_BUILDKIT=1 docker build -t ${projectName} .`,
+        // TODO: add `--env-file .env` with .env support
+        'image:run': `docker run --rm --net host ${projectName}`,
+      });
+    }
+
+    return {
+      asyncOperations,
+      syncOperations,
+    };
   };
 };

--- a/src/extensions/dockerize-workflow.test.js
+++ b/src/extensions/dockerize-workflow.test.js
@@ -32,8 +32,28 @@ describe('dockerize-workflow', () => {
       ops = toolbox.setupHusky(input);
     });
 
-    it('should return asyncOperations when the extension is called', () => {
+    it('should return syncOperations and asyncOperations when the extension is called', () => {
+      expect(ops.syncOperations).toBeDefined();
       expect(ops.asyncOperations).toBeDefined();
+    });
+
+    describe('syncOperations', () => {
+      let scripts;
+      let packages;
+
+      beforeEach(() => {
+        toolbox.dockerizeWorkflow(input).syncOperations();
+        scripts = Object.assign({}, ...input.pkgJsonScripts);
+        packages = input.pkgJsonInstalls.map((s) => s.split(' ')).flat(1);
+      });
+
+      it('should add a image:build script', () => {
+        expect(scripts['image:build']).toMatch(/docker build/);
+      });
+
+      it('should add a image:run script', () => {
+        expect(scripts['image:run']).toMatch(/docker run/);
+      });
     });
 
     describe('asyncOperations', () => {
@@ -71,6 +91,13 @@ describe('dockerize-workflow', () => {
         expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
           `${input.assetsPath}/Dockerfile`,
           `${input.appDir}/Dockerfile`
+        );
+      });
+
+      it('should copy .dockerignore', () => {
+        expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+          `${input.assetsPath}/.dockerignore`,
+          `${input.appDir}/.dockerignore`
         );
       });
 


### PR DESCRIPTION
This PR includes:
- bump Node version to 18 (Dockerfile)
- use a smaller Linux image (alpine)
- add `image:build` and `image:run` scripts
- add a `.dockerignore` file
- fix an issue where the image was only running because it was copying the `/dist`
- use a temporary image with dev devependencies to build the app
- run the application under the predefined `node` user
- enable [BuildKit](https://docs.docker.com/build/buildkit/)
- tested only with `Nest` for now as it's the only option with an example app