### PR TITLE
feat(logger): add request and error loging with pino

### DIFF
--- a/src/extensions/install-framework.js
+++ b/src/extensions/install-framework.js
@@ -66,6 +66,7 @@ module.exports = (toolbox) => {
         cors: '^2.8.5',
         compression: '^1.7.4',
         'http-terminator': '^3.2.0',
+        pino: '^8.11.0',
       });
 
       // with TypeScript
@@ -82,6 +83,7 @@ module.exports = (toolbox) => {
           '@types/express': '^4.17.17',
           '@types/cors': '^2.8.5',
           '@types/compression': '^1.7.2',
+          'pino-pretty': '^9.4.0',
         });
       }
     }

--- a/src/extensions/install-framework.test.js
+++ b/src/extensions/install-framework.test.js
@@ -127,6 +127,14 @@ describe('install-framework', () => {
         expect(dependencies).toHaveProperty('compression');
       });
 
+      it('should add http-terminator to dependencies', () => {
+        expect(dependencies).toHaveProperty('http-terminator');
+      });
+
+      it('should add pino to dependencies', () => {
+        expect(dependencies).toHaveProperty('pino');
+      });
+
       describe('and the language is TypeScript', () => {
         beforeAll(() => {
           input.projectLanguage = 'TS';
@@ -150,6 +158,10 @@ describe('install-framework', () => {
 
         it('should add @types/compression to devDependencies', () => {
           expect(devDependencies).toHaveProperty('@types/compression');
+        });
+
+        it('should add pino-pretty to devDependencies', () => {
+          expect(devDependencies).toHaveProperty('pino-pretty');
         });
       });
     });


### PR DESCRIPTION
- [x] adds `pino` and `pino-pretty`
- [x] adds request and error logging 
- [x] removes `process.on('uncaughtException', ...)` and `process.on('unhandledRejection', ...)` as advised [here](https://expressjs.com/en/advanced/best-practice-performance.html#what-not-to-do)
- [x] makes use of the `todoFieldsSchema` which was previously forgotten