### PR TITLE
fix(build): re-introduce tsc-alias

### DIFF
--- a/assets/tsconfig.build.json
+++ b/assets/tsconfig.build.json
@@ -1,4 +1,13 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts", "**/*.test.ts"]
+  "include": ["src/**/*"],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "test",
+    "**/*spec.ts",
+    "**/*.test.ts",
+    "**/*spec-e2e.ts",
+    "**/*.test-e2e.ts"
+  ]
 }

--- a/assets/tsconfig.json
+++ b/assets/tsconfig.json
@@ -8,24 +8,12 @@
     "skipLibCheck": false,
     "lib": ["ES2021"],
     "paths": {
-      "@api": [
-        "src/api"
-      ],
-      "@modules": [
-        "src/modules"
-      ],
-      "@common": [
-        "src/common"
-      ],
-      "@database": [
-        "src/database"
-      ]
-    }, 
-    "skipLibCheck": false,
-    "lib": ["ES2021"]
+      "@api": ["src/api"],
+      "@modules": ["src/modules"],
+      "@common": ["src/common"],
+      "@database": ["src/database"]
+    }
   },
-  "include": ["src/**/*"],
-  "exclude": ["**/*.spec.*", "**/*.test.*"],
   "ts-node": {
     "files": true,
     "require": [

--- a/src/extensions/ts-setup.js
+++ b/src/extensions/ts-setup.js
@@ -39,13 +39,14 @@ module.exports = (toolbox) => {
 
         Object.assign(pkgJson.scripts, {
           clean: 'rimraf dist',
-          build: 'npm run clean && tsc --build',
+          build: 'npm run clean && tsc -p tsconfig.build.json && tsc-alias',
         });
 
         Object.assign(pkgJson.devDependencies, {
           typescript: '^4.9.5',
           '@tsconfig/recommended': '^1.0.2',
           'tsconfig-paths': '^4.1.2',
+          'tsc-alias': '^1.8.2',
           '@types/node': '^18.14.0',
           rimraf: '^4.1.2',
           'ts-node': '^10.9.1',

--- a/src/extensions/ts-setup.test.js
+++ b/src/extensions/ts-setup.test.js
@@ -74,27 +74,31 @@ describe('ts-setup', () => {
           expect(scripts['build']).toBeDefined();
         });
 
-        it('should add the typescript package', () => {
+        it('should add the typescript devDependency', () => {
           expect(devDependencies).toHaveProperty('typescript');
         });
 
-        it('should add the @tsconfig/recommended package', () => {
+        it('should add the @tsconfig/recommended devDependency', () => {
           expect(devDependencies).toHaveProperty('@tsconfig/recommended');
         });
 
-        it('should add the tsconfig-paths package', () => {
+        it('should add the tsconfig-paths devDependency', () => {
           expect(devDependencies).toHaveProperty('tsconfig-paths');
         });
 
-        it('should add the @types/node package', () => {
+        it('should add the tsc-alias devDependency', () => {
+          expect(devDependencies).toHaveProperty('tsc-alias');
+        });
+
+        it('should add the @types/node devDependency', () => {
           expect(devDependencies).toHaveProperty('@types/node');
         });
 
-        it('should add the rimraf package', () => {
+        it('should add the rimraf devDependency', () => {
           expect(devDependencies).toHaveProperty('rimraf');
         });
 
-        it('should add the ts-node package', () => {
+        it('should add the ts-node devDependency', () => {
           expect(devDependencies).toHaveProperty('ts-node');
         });
       });


### PR DESCRIPTION
Turns out `tsc-alias` is still needed.

- [x] update the `build` script to use `tsc-alias` and to use `tsconfig.build.json`
- [x] move `include` and `exclude` to `tsconfig.build.json`