### PR TITLE
feat(openapi): add openapi generation script

### DIFF
--- a/assets/express/.openapi/.gitignore
+++ b/assets/express/.openapi/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/assets/express/scripts/generate-openapi.ts
+++ b/assets/express/scripts/generate-openapi.ts
@@ -1,0 +1,37 @@
+import '../src/extensions/zod/register';
+import '../src/extensions/knex/register';
+
+import pino from 'pino';
+import { envSchema } from '../src/common';
+
+import { initApplication } from '../src/app'
+import { writeFileSync } from 'fs';
+import { resolve } from 'path';
+
+const run = async () => {
+  const env = envSchema.parse(process.env);
+
+  const logger = pino({
+    name: 'http',
+    ...(env.NODE_ENV !== 'production' && {
+      transport: {
+        target: 'pino-pretty',
+        colorize: false,
+      },
+    }),
+  });
+
+  const { createOpenAPIDocument } = await initApplication(logger);
+
+  const document = createOpenAPIDocument();
+  const file = resolve(__dirname, '..', '.openapi', 'openapi.json');
+  const data = JSON.stringify(document, null, 2);
+
+  writeFileSync(file, data);
+
+  return file;
+}
+
+run()
+  .then(console.log)
+  .catch(console.error);

--- a/assets/express/src/app.ts
+++ b/assets/express/src/app.ts
@@ -9,7 +9,6 @@ import apiDefinitionFactory from '@api';
 import { initializeMiddlewares, validateRequest } from './api/middleware';
 import { registry } from './modules';
 import { OpenAPIGenerator } from '@asteasolutions/zod-to-openapi';
-import { writeFileSync } from 'fs';
 import { asyncHandler } from '@common';
 
 export async function initApplication(logger: Logger) {
@@ -45,7 +44,7 @@ export async function initApplication(logger: Logger) {
   return {
     app,
     knex,
-    createSwaggerDocument: () => {
+    createOpenAPIDocument: () => {
       for (const {
         operationId,
         tags,
@@ -90,28 +89,26 @@ export async function initApplication(logger: Logger) {
                     description:
                       httpStatuses.message[code as never as number] ??
                       'Unknown response code',
-                    condent: { 'application/json': { schema } },
+                    content: { 'application/json': { schema } },
                   }
                 : schema,
             ])
           ),
         });
-
-        const generator = new OpenAPIGenerator(registry.definitions, '3.0.0');
-
-        const document = generator.generateDocument({
-          info: {
-            version: '1.0.0',
-            title: 'My API',
-            description: 'This is the API',
-          },
-          servers: [{ url: '' }],
-        });
-
-        writeFileSync('swagger.json', JSON.stringify(document, null, 2), {
-          encoding: 'utf-8',
-        });
       }
+
+      const generator = new OpenAPIGenerator(registry.definitions, '3.0.0');
+
+      const document = generator.generateDocument({
+        info: {
+          version: '1.0.0',
+          title: 'My API',
+          description: 'This is the API',
+        },
+        servers: [{ url: '' }],
+      });
+
+      return document;
     },
   };
 }

--- a/assets/express/src/index.ts
+++ b/assets/express/src/index.ts
@@ -3,13 +3,13 @@ import './extensions/knex/register';
 
 import pino from 'pino';
 import { createHttpTerminator } from 'http-terminator';
-import { Environment, envSchema } from '@common';
+import { envSchema } from '@common';
 
 import { initApplication } from './app';
-import { existsSync } from 'fs';
 
 async function bootstrap() {
-  const env: Environment = envSchema.parse(process.env);
+  const env = envSchema.parse(process.env);
+
   const logger = pino({
     name: 'http',
     ...(env.NODE_ENV !== 'production' && {
@@ -20,11 +20,7 @@ async function bootstrap() {
     }),
   });
 
-  const { app, knex, createSwaggerDocument } = await initApplication(logger);
-
-  if (!existsSync('../swagger.json')) {
-    createSwaggerDocument();
-  }
+  const { app, knex } = await initApplication(logger);
 
   // Start server
   const server = app.listen(env.PORT, () => {

--- a/src/extensions/dockerize-workflow.js
+++ b/src/extensions/dockerize-workflow.js
@@ -21,7 +21,9 @@ module.exports = (toolbox) => {
       try {
         await Promise.all([
           copyAsync(`${assetsPath}/.project-npmignr`, `${appDir}/.npmignore`),
-          copyAsync(`${assetsPath}/scripts/`, `${appDir}/scripts/`),
+          copyAsync(`${assetsPath}/scripts/`, `${appDir}/scripts/`, {
+            overwrite: true,
+          }),
           copyAsync(`${assetsPath}/Dockerfile`, `${appDir}/Dockerfile`),
           copyAsync(`${assetsPath}/.dockerignore`, `${appDir}/.dockerignore`),
           copyAsync(

--- a/src/extensions/dockerize-workflow.test.js
+++ b/src/extensions/dockerize-workflow.test.js
@@ -81,7 +81,8 @@ describe('dockerize-workflow', () => {
       it('should copy scripts', () => {
         expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
           `${input.assetsPath}/scripts/`,
-          `${input.appDir}/scripts/`
+          `${input.appDir}/scripts/`,
+          { overwrite: true }
         );
       });
 

--- a/src/extensions/install-framework.test.js
+++ b/src/extensions/install-framework.test.js
@@ -177,6 +177,45 @@ describe('install-framework', () => {
           expect(devDependencies).toHaveProperty('@types/statuses');
         });
 
+        it('should add the OpenAPI env var section', () => {
+          expect(envVars).toHaveProperty('OpenAPI');
+          expect(envVars['OpenAPI']).toHaveProperty('SWAGGER_UI_PORT');
+        });
+
+        it('shoudl add the openapi scripts', () => {
+          expect(Object.keys(scripts)).toEqual(
+            expect.arrayContaining([
+              'openapi:g',
+              'openapi:ui:run',
+              'openapi:ui:open',
+              'openapi:serve',
+            ])
+          );
+        });
+
+        it('should add concurrently to devDependencies', () => {
+          expect(devDependencies).toHaveProperty('concurrently');
+        });
+
+        it('should add open to devDependencies', () => {
+          expect(devDependencies).toHaveProperty('open');
+        });
+
+        it('should copy the openapi-generate script', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${input.assetsPath}/express/scripts`,
+            `${input.appDir}/scripts`,
+            { overwrite: true }
+          );
+        });
+
+        it('should copy the .openapi dir', () => {
+          expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+            `${input.assetsPath}/express/.openapi`,
+            `${input.appDir}/.openapi`
+          );
+        });
+
         describe('and the database is PostgreSQL', () => {
           beforeAll(() => {
             input.db = 'pg';


### PR DESCRIPTION
- [x] fix `openapi` generation (a typo `condent` and an early return in the loop of routes)
- [x] move `openapi` out of the API entry point into `/scripts`
- [x] add a package script for running the generation script
- [x] add a package script for serving `swagger-ui`

**PS:** You need to generate the `openapi.json` file once, then start the docker container. Consequent regeneration will be reflected after a page refresh.

**PS:** Swagger UI is intentionally kept out of `docker-compose.yml` as it can be used for running e2e tests in a CI environment.