### PR TITLE
feat(zod): add post coercion for numbers

### DIFF
--- a/assets/express/src/api/v1/todos/dto/todo-id.dto.ts
+++ b/assets/express/src/api/v1/todos/dto/todo-id.dto.ts
@@ -1,5 +1,6 @@
-import { z } from 'zod';
+import z from 'zod';
+import { todo } from '@common/data/models';
 
 export const todoIdDTO = z.object({
-  id: z.coerce.number().int().positive().openapi({ example: 1 }),
+  id: todo.shape.id.coerce(),
 });

--- a/assets/express/src/extensions/zod/index.ts
+++ b/assets/express/src/extensions/zod/index.ts
@@ -1,6 +1,12 @@
 import z from 'zod';
 import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 
+declare module 'zod' {
+  interface ZodNumber {
+    coerce(): ZodNumber;
+  }
+}
+
 declare module '@asteasolutions/zod-to-openapi' {
   interface ZodOpenAPIMetadata {
     schemaName: string;
@@ -8,5 +14,17 @@ declare module '@asteasolutions/zod-to-openapi' {
 }
 
 export const register = () => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  if (typeof z.ZodNumber.prototype.coerce === 'undefined') {
+    z.ZodNumber.prototype.coerce = function () {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      return new (this as any).constructor({
+        ...this._def,
+        coerce: true,
+      });
+    };
+  }
+
   extendZodWithOpenApi(z);
 };


### PR DESCRIPTION
- [x] you can now add coercion to an existing number schema, which allows for `id` schema reuse in request params and query