### PR TITLE
fix: make debug and readme generally available

### DIFF
--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -110,6 +110,8 @@ module.exports = {
 
     stepsOfExecution.push(toolbox.jestConfig(userInput));
     stepsOfExecution.push(toolbox.auditConfig(userInput));
+    stepsOfExecution.push(toolbox.debug(userInput));
+    stepsOfExecution.push(toolbox.generateReadme(userInput));
 
     if (userInput.projectLanguage === 'TS' && userInput.framework !== 'nest') {
       stepsOfExecution.push(toolbox.setupTs(userInput));
@@ -171,6 +173,7 @@ module.exports = {
       ...userInput.pkgJson.devDependencies,
     };
 
+    // TODO: move out
     if (pickedFramework === 'nest') {
       packageJson.jest.coveragePathIgnorePatterns = [
         '<rootDir>/main.ts$',

--- a/src/extensions/debug.js
+++ b/src/extensions/debug.js
@@ -1,0 +1,39 @@
+'use strict';
+
+module.exports = (toolbox) => {
+  toolbox.debug = ({
+    framework,
+    projectLanguage,
+    pkgJson,
+    assetsPath,
+    appDir,
+  }) => {
+    const {
+      filesystem: { copyAsync },
+    } = toolbox;
+
+    function syncOperations() {
+      if (framework === 'nest') {
+        return;
+      }
+
+      const debugScript =
+        projectLanguage === 'TS'
+          ? 'tsc --sourceMap -p tsconfig.build.json && tsc-alias && node --inspect -r dotenv/config dist/index'
+          : 'node --inspect -r dotenv/config src/index';
+
+      Object.assign(pkgJson.scripts, {
+        'start:debug': debugScript,
+      });
+    }
+
+    async function asyncOperations() {
+      await copyAsync(`${assetsPath}/vscode/`, `${appDir}/.vscode/`);
+    }
+
+    return {
+      syncOperations,
+      asyncOperations,
+    };
+  };
+};

--- a/src/extensions/debug.test.js
+++ b/src/extensions/debug.test.js
@@ -1,0 +1,77 @@
+const extend = require('./debug');
+const {
+  createToolboxMock,
+  createExtensionInput,
+} = require('../utils/test/mocks');
+
+describe('debug-extension', () => {
+  let toolbox;
+
+  beforeEach(() => {
+    toolbox = createToolboxMock();
+    extend(toolbox);
+  });
+
+  it('should be defined', () => {
+    expect(extend).toBeDefined();
+  });
+
+  it('should set debug on toolbox', () => {
+    expect(toolbox.debug).toBeDefined();
+  });
+
+  describe('debug', () => {
+    let input;
+    let ops;
+
+    beforeAll(() => {
+      input = createExtensionInput();
+    });
+
+    beforeEach(() => {
+      ops = toolbox.debug(input);
+    });
+
+    it('should return syncOperations and asyncOperations when the extension is called', () => {
+      expect(ops.syncOperations).toBeDefined();
+      expect(ops.asyncOperations).toBeDefined();
+    });
+
+    describe('syncOperations', () => {
+      let scripts;
+
+      beforeAll(() => {
+        input.framework = 'nest';
+      });
+
+      beforeEach(() => {
+        ops.syncOperations();
+        scripts = input.pkgJson.scripts;
+      });
+
+      describe('when the framework is not nest', () => {
+        beforeAll(() => {
+          input.framework = 'express';
+        });
+
+        it('should add the start:debug script', () => {
+          expect(scripts).toHaveProperty('start:debug');
+        });
+      });
+    });
+
+    describe('asyncOperations', () => {
+      beforeEach(async () => {
+        toolbox.filesystem.copyAsync = jest.fn(() => {});
+        await toolbox.debug(input).asyncOperations();
+      });
+
+      it('should copy the vscode folder', () => {
+        expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+          `${input.assetsPath}/vscode/`,
+          `${input.appDir}/.vscode/`
+        );
+      });
+    });
+  });
+});

--- a/src/extensions/generate-readme.js
+++ b/src/extensions/generate-readme.js
@@ -1,0 +1,54 @@
+'use strict';
+
+module.exports = (toolbox) => {
+  toolbox.generateReadme = ({
+    projectName,
+    projectLanguage,
+    features,
+    appDir,
+    db,
+    isExampleApp,
+  }) => {
+    const {
+      template: { generate },
+    } = toolbox;
+
+    async function asyncOperations() {
+      await generate({
+        template: 'README.md.ejs',
+        target: `${appDir}/README.md`,
+        props: {
+          projectName,
+          prerequisites: {
+            pip3:
+              features.includes('huskyHooks') || features.includes('preCommit'),
+            docker: features.includes('dockerizeWorkflow'),
+            dockerCompose: db === 'pg',
+          },
+          setup: {
+            dockerCompose: db === 'pg',
+            migrations: isExampleApp,
+            tests: {
+              unit: true,
+              e2e: isExampleApp,
+            },
+          },
+          run: {
+            build: projectLanguage === 'TS',
+            debug: true,
+          },
+          test: {
+            e2e: isExampleApp,
+          },
+          debug: {
+            vscode: true,
+          },
+        },
+      });
+    }
+
+    return {
+      asyncOperations,
+    };
+  };
+};

--- a/src/extensions/generate-readme.test.js
+++ b/src/extensions/generate-readme.test.js
@@ -1,0 +1,50 @@
+const extend = require('./generate-readme');
+const {
+  createToolboxMock,
+  createExtensionInput,
+} = require('../utils/test/mocks');
+
+describe('generate-readme', () => {
+  let toolbox;
+
+  beforeEach(() => {
+    toolbox = createToolboxMock();
+    extend(toolbox);
+  });
+
+  it('should be defined', () => {
+    expect(extend).toBeDefined();
+  });
+
+  it('should set generateReadme on toolbox', () => {
+    expect(toolbox.generateReadme).toBeDefined();
+  });
+
+  describe('generateReadme', () => {
+    const input = createExtensionInput();
+    let ops;
+
+    beforeAll(() => {
+      ops = toolbox.generateReadme(input);
+    });
+
+    it('should return asyncOperations when the extension is called', () => {
+      expect(ops.asyncOperations).toBeDefined();
+    });
+
+    describe('asyncOperations', () => {
+      beforeEach(async () => {
+        toolbox.template.generate = jest.fn();
+        await toolbox.generateReadme(input).asyncOperations();
+      });
+
+      it('should render the README template', () => {
+        expect(toolbox.template.generate).toHaveBeenCalledWith({
+          template: 'README.md.ejs',
+          target: `${input.appDir}/README.md`,
+          props: expect.anything(),
+        });
+      });
+    });
+  });
+});

--- a/src/extensions/install-framework.js
+++ b/src/extensions/install-framework.js
@@ -2,15 +2,12 @@
 
 module.exports = (toolbox) => {
   toolbox.installFramework = async ({
-    projectName,
     projectLanguage,
     framework,
-    features,
     appDir,
     assetsPath,
     pkgJson,
     envVars,
-    db,
     isExampleApp,
   }) => {
     const {
@@ -52,17 +49,6 @@ module.exports = (toolbox) => {
         exec: pkgJson.scripts['start'],
       },
     });
-
-    const debugScript =
-      projectLanguage === 'TS'
-        ? 'tsc --sourceMap -p tsconfig.build.json && tsc-alias && node --inspect -r dotenv/config dist/index'
-        : 'node --inspect -r dotenv/config src/index';
-
-    Object.assign(pkgJson.scripts, {
-      'start:debug': debugScript,
-    });
-
-    await copyAsync(`${assetsPath}/vscode/`, `${appDir}/.vscode/`);
 
     // Express
     if (framework === 'express') {
@@ -177,41 +163,6 @@ module.exports = (toolbox) => {
         overwrite: true,
       });
     }
-
-    // README.md
-    // TODO: move out
-    await generate({
-      template: 'README.md.ejs',
-      target: `${appDir}/README.md`,
-      props: {
-        projectName,
-        prerequisites: {
-          pip3:
-            features.includes('huskyHooks') || features.includes('preCommit'),
-          docker: features.includes('dockerizeWorkflow'),
-          dockerCompose: db === 'pg',
-        },
-        setup: {
-          dockerCompose: db === 'pg',
-          migrations:
-            projectLanguage === 'TS' && framework === 'express' && db === 'pg',
-          tests: {
-            unit: true,
-            e2e: isExampleApp,
-          },
-        },
-        run: {
-          build: projectLanguage === 'TS',
-          debug: true,
-        },
-        test: {
-          e2e: isExampleApp,
-        },
-        debug: {
-          vscode: projectLanguage === 'TS',
-        },
-      },
-    });
 
     success(
       `${framework} installation completed successfully. Please wait for the other steps to be completed...`

--- a/src/extensions/install-framework.test.js
+++ b/src/extensions/install-framework.test.js
@@ -88,17 +88,6 @@ describe('install-framework', () => {
       });
     });
 
-    it('should add the start:debug script', () => {
-      expect(scripts).toHaveProperty('start:debug');
-    });
-
-    it('should copy the vscode folder', () => {
-      expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
-        `${input.assetsPath}/vscode/`,
-        `${input.appDir}/.vscode/`
-      );
-    });
-
     describe('when the framework is express', () => {
       beforeAll(() => {
         input.projectLanguage = 'JS'; // else-branch coverage
@@ -313,14 +302,6 @@ describe('install-framework', () => {
           `${input.appDir}/scripts`,
           { overwrite: true }
         );
-      });
-    });
-
-    it('should render the README template', () => {
-      expect(toolbox.template.generate).toHaveBeenCalledWith({
-        template: 'README.md.ejs',
-        target: `${input.appDir}/README.md`,
-        props: expect.anything(),
       });
     });
   });

--- a/src/utils/test/mocks.js
+++ b/src/utils/test/mocks.js
@@ -110,6 +110,13 @@ const createToolboxMock = () => ({
     syncOperations: () => {},
     asyncOperations: async () => {},
   }),
+  generateReadme: () => ({
+    asyncOperations: async () => {},
+  }),
+  debug: () => ({
+    syncOperations: () => {},
+    asyncOperations: async () => {},
+  }),
 });
 
 const createExtensionInput = () => ({


### PR DESCRIPTION
- [x] generate `README.md` for `NestJS` apps
- [x] copy `.vscode/launch` for `NestJS` apps