### PR TITLE
fix: fix detect-secret version

### DIFF
--- a/assets/detect-secrets.sh
+++ b/assets/detect-secrets.sh
@@ -6,11 +6,19 @@ then
     echo "detect-secrets could not be found. Installing detect-secrets..."
     if command -v pip3 &> /dev/null
     then
-      pip3 install detect-secrets
+      pip3 install detect-secrets==1.4.0 --upgrade
     else
       echo "pip3 not found, could not install detect-secrets"
       exit 1
     fi
+fi
+
+# Switch to the needed version
+DETECT_SECRETS_VERSION=$(detect-secrets --version)
+
+if [ "$DETECT_SECRETS_VERSION" != "1.4.0" ]
+then
+  pip3 install detect-secrets==1.4.0 --upgrade
 fi
 
 # Install pre-commit if not found

--- a/assets/local-scripts/initiate-detect-secrets.sh
+++ b/assets/local-scripts/initiate-detect-secrets.sh
@@ -19,7 +19,15 @@ fi
 if ! command -v detect-secrets &> /dev/null
 then
   echo "detect-secrets could not be found. Installing detect-secrets..."
-  pip3 install detect-secrets
+  pip3 install detect-secrets==1.4.0 --upgrade
+fi
+
+# Switch to the needed version
+DETECT_SECRETS_VERSION=$(detect-secrets --version)
+
+if [ "$DETECT_SECRETS_VERSION" != "1.4.0" ]
+then
+  pip3 install detect-secrets==1.4.0 --upgrade
 fi
 
 pre-commit autoupdate

--- a/src/extensions/husky-setup-extension.js
+++ b/src/extensions/husky-setup-extension.js
@@ -118,8 +118,6 @@ module.exports = (toolbox) => {
       }
 
       if (features.includes('preCommit')) {
-        pkgJson.scripts['initsecrets'] = 'scripts/detect-secrets.sh';
-
         Object.assign(pkgJson.devDependencies, {
           'lint-staged': '^13.1.2',
           'sort-package-json': '^2.4.1',

--- a/src/extensions/husky-setup-extension.test.js
+++ b/src/extensions/husky-setup-extension.test.js
@@ -88,10 +88,6 @@ describe('husky-setup-extension', () => {
           input.features = ['preCommit'];
         });
 
-        it('should add the init secrets script', () => {
-          expect(scripts['initsecrets']).toBeDefined();
-        });
-
         it('should add the lint-staged package', () => {
           expect(devDependencies).toHaveProperty('lint-staged');
         });

--- a/src/templates/husky/pre-commit.ejs
+++ b/src/templates/husky/pre-commit.ejs
@@ -4,9 +4,9 @@
 <% if (props.ts) { %>npx --no -- tsc --noEmit<% } %>
 npx --no -- lint-staged
 npx --no -- ls-lint
-npm run initsecrets
 <% if (props.test.unit) { %>npm run test:cov<% } %>
 <% if (props.test.e2e) { %>npm run test:e2e:cov<% } %>
+scripts/detect-secrets.sh
 pre-commit run
 
 # Enable branch naming validation by uncommenting the lines below and adjust valid_branch_regex to your preference


### PR DESCRIPTION
- [x] fix `detect-secrets` at `1.4.0` to match `rev` in `pre-commit` config during install
- [x] attempt to up/downgrade `detect-secrets` to `1.4.0` when another version is present
- [x] remove `initsecrets` script as `detect-secrets` is considering it a secret and includes it in the baseline