### PR TITLE
fix(openapi): await for the swagger container to start

### DIFF
--- a/assets/express/example-app/scripts/await-openapi-ui-start.sh
+++ b/assets/express/example-app/scripts/await-openapi-ui-start.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+CONTAINER_NAME=$1
+
+# Wait for the first container start event
+grep -m 1 "container start" <(docker events --filter type=container --filter event=start --filter container="$CONTAINER_NAME")

--- a/src/extensions/install-framework.test.js
+++ b/src/extensions/install-framework.test.js
@@ -264,6 +264,13 @@ describe('install-framework', () => {
         );
       });
 
+      it('should copy the openapi container await script', () => {
+        expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+          `${input.assetsPath}/express/example-app/scripts/await-openapi-ui-start.sh`,
+          `${input.appDir}/scripts/await-openapi-ui-start.sh`
+        );
+      });
+
       it('should copy the .openapi dir', () => {
         expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
           `${input.assetsPath}/express/example-app/.openapi`,


### PR DESCRIPTION
- [x] fix `openpi:serve` opening `SwaggerUI` before the container has started

Solution found [here](https://unix.stackexchange.com/questions/679658/kill-process-once-it-produces-certain-output)