### PR TITLE
feat(license-check): add a license check using osi as a baseline

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 npx --no -- lint-staged -c .lintstagedrc.js
+npm run license:check

--- a/assets/.eslintignore
+++ b/assets/.eslintignore
@@ -5,3 +5,4 @@ dist/
 *.config.js
 *rc.js
 src/extensions/**/*.js
+licenses-allowed.js

--- a/assets/licenses/licenses-allowed.js
+++ b/assets/licenses/licenses-allowed.js
@@ -1,0 +1,11 @@
+const spdxLicenses = require('spdx-license-list');
+
+const separator = process.argv[2];
+
+const osiApprovedLicenses = Object.entries(spdxLicenses)
+  .filter(([, value]) => value.osiApproved)
+  .map(([k]) => k);
+
+const reviewedLicenses = require('./licenses-reviewed');
+
+console.log(osiApprovedLicenses.concat(reviewedLicenses).join(separator));

--- a/assets/licenses/licenses-reviewed.js
+++ b/assets/licenses/licenses-reviewed.js
@@ -1,0 +1,34 @@
+module.exports = [
+  /**
+   * @link https://creativecommons.org/licenses/by/1.0/
+   *
+   * Dependencies:
+   *  spdx-license-ids
+   *  spdx-license-list
+   */
+  'CC0-1.0',
+
+  /**
+   * @link https://creativecommons.org/licenses/by/3.0/
+   *
+   * Dependencies:
+   *  spdx-ranges
+   */
+  'CC-BY-3.0',
+
+  /**
+   * @link https://creativecommons.org/licenses/by/4.0/
+   *
+   * Dependencies:
+   *  caniuse-lite
+   */
+  'CC-BY-4.0',
+
+  /**
+   * @link https://blueoakcouncil.org/license/1.0.0
+   *
+   * Dependencies:
+   *  markdownlint-cli
+   */
+  'BlueOak-1.0.0',
+];

--- a/docs/features.md
+++ b/docs/features.md
@@ -108,6 +108,12 @@ node-cli g <project-name>
 - `test:e2e:cov` script
 - uses `.env.test` via `DOTENV_CONFIG_PATH` env var
 
+### License Check
+
+- `license:check` script
+- `license:for-review` script
+- `license:summary` script
+
 ### Application features
 
 - security headers via `helmet`

--- a/licenses-allowed.js
+++ b/licenses-allowed.js
@@ -1,0 +1,11 @@
+const spdxLicenses = require('spdx-license-list');
+
+const separator = process.argv[2];
+
+const osiApprovedLicenses = Object.entries(spdxLicenses)
+  .filter(([, value]) => value.osiApproved)
+  .map(([k]) => k);
+
+const reviewedLicenses = require('./licenses-reviewed');
+
+console.log(osiApprovedLicenses.concat(reviewedLicenses).join(separator));

--- a/licenses-reviewed.js
+++ b/licenses-reviewed.js
@@ -1,0 +1,34 @@
+module.exports = [
+  /**
+   * @link https://creativecommons.org/licenses/by/1.0/
+   *
+   * Dependencies:
+   *  spdx-license-ids
+   *  spdx-license-list
+   */
+  'CC0-1.0',
+
+  /**
+   * @link https://creativecommons.org/licenses/by/3.0/
+   *
+   * Dependencies:
+   *  spdx-ranges
+   */
+  'CC-BY-3.0',
+
+  /**
+   * @link https://creativecommons.org/licenses/by/4.0/
+   *
+   * Dependencies:
+   *  caniuse-lite
+   */
+  'CC-BY-4.0',
+
+  /**
+   * @link https://blueoakcouncil.org/license/1.0.0
+   *
+   * Dependencies:
+   *  markdownlint-cli
+   */
+  'BlueOak-1.0.0',
+];

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,10 +22,12 @@
         "eslint-plugin-security": "^1.7.1",
         "husky": "^8.0.3",
         "jest": "^29.4.2",
+        "license-checker": "^25.0.1",
         "lint-staged": "^13.1.2",
         "markdownlint-cli": "^0.34.0",
         "prettier": "^2.8.4",
-        "sort-package-json": "^2.4.1"
+        "sort-package-json": "^2.4.1",
+        "spdx-license-list": "^6.6.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2331,6 +2333,12 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "node_modules/acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -2476,6 +2484,15 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -2490,6 +2507,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true
     },
     "node_modules/astral-regex": {
       "version": "2.0.0",
@@ -3229,6 +3252,15 @@
         }
       }
     },
+    "node_modules/debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -3317,6 +3349,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff": {
@@ -6627,6 +6669,45 @@
         "node": ">=6"
       }
     },
+    "node_modules/license-checker": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/license-checker/-/license-checker-25.0.1.tgz",
+      "integrity": "sha512-mET5AIwl7MR2IAKYYoVBBpV0OnkKQ1xGj2IMMeEFIs42QAkEVjRtFZGWmQ28WeU7MP779iAgOaOy93Mn44mn6g==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.1",
+        "debug": "^3.1.0",
+        "mkdirp": "^0.5.1",
+        "nopt": "^4.0.1",
+        "read-installed": "~4.0.3",
+        "semver": "^5.5.0",
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-satisfies": "^4.0.0",
+        "treeify": "^1.1.0"
+      },
+      "bin": {
+        "license-checker": "bin/license-checker"
+      }
+    },
+    "node_modules/license-checker/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/license-checker/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
@@ -7444,6 +7525,18 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -7467,6 +7560,19 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
       "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
+    },
+    "node_modules/nopt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      }
     },
     "node_modules/normalize-package-data": {
       "version": "2.5.0",
@@ -7497,6 +7603,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+      "dev": true
     },
     "node_modules/npm-run-path": {
       "version": "4.0.1",
@@ -7582,6 +7694,34 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "dependencies": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "node_modules/p-limit": {
@@ -7894,6 +8034,44 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/read-installed": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+      "integrity": "sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==",
+      "dev": true,
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "slide": "~1.1.3",
+        "util-extend": "^1.0.1"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/read-installed/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/read-package-json": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.2.tgz",
+      "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "normalize-package-data": "^2.0.0",
+        "npm-normalize-package-bin": "^1.0.0"
+      }
+    },
     "node_modules/read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -7947,6 +8125,19 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-scoped-modules": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "dev": true,
+      "dependencies": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
       }
     },
     "node_modules/redent": {
@@ -8295,6 +8486,15 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sort-object-keys": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
@@ -8361,6 +8561,17 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/spdx-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+      "dev": true,
+      "dependencies": {
+        "array-find-index": "^1.0.2",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
+    },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -8392,6 +8603,35 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
+    },
+    "node_modules/spdx-license-list": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-6.6.0.tgz",
+      "integrity": "sha512-vLwdf9AWgdJQmG8cai2HKfkInFsliKaCCOwXmdVonClIhdURTX61KdDOoXC1qcQ7gDaZj+CUTcrMJeAdnCtrKA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/spdx-ranges": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
+      "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==",
+      "dev": true
+    },
+    "node_modules/spdx-satisfies": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.1.tgz",
+      "integrity": "sha512-WVzZ/cXAzoNmjCWiEluEA3BjHp5tiUmmhn9MK+X0tBbR9sOqtC6UQwmgCNrAIZvNlMuBUYAaHYfb2oqlF9SwKA==",
+      "dev": true,
+      "dependencies": {
+        "spdx-compare": "^1.0.0",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
     },
     "node_modules/split2": {
       "version": "3.2.2",
@@ -8647,6 +8887,15 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -8790,6 +9039,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "node_modules/util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha512-mLs5zAK+ctllYBj+iAQvlDCwoxU/WDOUaJkcFudeiAX6OajC6BKXJUa9a+tbtkC11dz2Ufb7h0lyvIOVn4LADA==",
       "dev": true
     },
     "node_modules/v8-compile-cache-lib": {
@@ -10838,6 +11093,12 @@
       "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
       "dev": true
     },
+    "abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true
+    },
     "acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
@@ -10946,6 +11207,12 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+      "dev": true
+    },
     "array-ify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-ify/-/array-ify-1.0.0.tgz",
@@ -10956,6 +11223,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true
+    },
+    "asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
     "astral-regex": {
@@ -11479,6 +11752,12 @@
         "ms": "2.1.2"
       }
     },
+    "debuglog": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/debuglog/-/debuglog-1.0.1.tgz",
+      "integrity": "sha512-syBZ+rnAK3EgMsH2aYEOLUW7mZSY9Gb+0wUMCFsZvcmiz+HigA0LOcq/HoQqVuGG+EKykunc7QG2bzrponfaSw==",
+      "dev": true
+    },
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
@@ -11546,6 +11825,16 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
+    },
+    "dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "requires": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
+      }
     },
     "diff": {
       "version": "4.0.2",
@@ -13961,6 +14250,41 @@
       "integrity": "sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==",
       "dev": true
     },
+    "license-checker": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/license-checker/-/license-checker-25.0.1.tgz",
+      "integrity": "sha512-mET5AIwl7MR2IAKYYoVBBpV0OnkKQ1xGj2IMMeEFIs42QAkEVjRtFZGWmQ28WeU7MP779iAgOaOy93Mn44mn6g==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.1",
+        "debug": "^3.1.0",
+        "mkdirp": "^0.5.1",
+        "nopt": "^4.0.1",
+        "read-installed": "~4.0.3",
+        "semver": "^5.5.0",
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-satisfies": "^4.0.0",
+        "treeify": "^1.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
     "lilconfig": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.0.6.tgz",
@@ -14588,6 +14912,15 @@
       "integrity": "sha512-MzWSV5nYVT7mVyWCwn2o7JH13w2TBRmmSqSRCKzTw+lmft9X4z+3wjvs06Tzijo5z4W/kahUCDpRXTF+ZrmF/w==",
       "dev": true
     },
+    "mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.6"
+      }
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -14611,6 +14944,16 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.10.tgz",
       "integrity": "sha512-5GFldHPXVG/YZmFzJvKK2zDSzPKhEp0+ZR5SVaoSag9fsL5YgHbUHDfnG5494ISANDcK4KwPXAx2xqVEydmd7w==",
       "dev": true
+    },
+    "nopt": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
+      "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+      "dev": true,
+      "requires": {
+        "abbrev": "1",
+        "osenv": "^0.1.4"
+      }
     },
     "normalize-package-data": {
       "version": "2.5.0",
@@ -14636,6 +14979,12 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true
+    },
+    "npm-normalize-package-bin": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
       "dev": true
     },
     "npm-run-path": {
@@ -14700,6 +15049,28 @@
             "ansi-regex": "^4.1.0"
           }
         }
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
+      "dev": true
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true
+    },
+    "osenv": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+      "dev": true,
+      "requires": {
+        "os-homedir": "^1.0.0",
+        "os-tmpdir": "^1.0.0"
       }
     },
     "p-limit": {
@@ -14902,6 +15273,41 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "read-installed": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/read-installed/-/read-installed-4.0.3.tgz",
+      "integrity": "sha512-O03wg/IYuV/VtnK2h/KXEt9VIbMUFbk3ERG0Iu4FhLZw0EP0T9znqrYDGn6ncbEsXUFaUjiVAWXHzxwt3lhRPQ==",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "graceful-fs": "^4.1.2",
+        "read-package-json": "^2.0.0",
+        "readdir-scoped-modules": "^1.0.0",
+        "semver": "2 || 3 || 4 || 5",
+        "slide": "~1.1.3",
+        "util-extend": "^1.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "read-package-json": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.2.tgz",
+      "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "normalize-package-data": "^2.0.0",
+        "npm-normalize-package-bin": "^1.0.0"
+      }
+    },
     "read-pkg": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -14942,6 +15348,18 @@
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
         "util-deprecate": "^1.0.1"
+      }
+    },
+    "readdir-scoped-modules": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/readdir-scoped-modules/-/readdir-scoped-modules-1.1.0.tgz",
+      "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
+      "dev": true,
+      "requires": {
+        "debuglog": "^1.0.1",
+        "dezalgo": "^1.0.0",
+        "graceful-fs": "^4.1.2",
+        "once": "^1.3.0"
       }
     },
     "redent": {
@@ -15183,6 +15601,12 @@
         }
       }
     },
+    "slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "dev": true
+    },
     "sort-object-keys": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
@@ -15233,6 +15657,17 @@
         "source-map": "^0.6.0"
       }
     },
+    "spdx-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+      "dev": true,
+      "requires": {
+        "array-find-index": "^1.0.2",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
+    },
     "spdx-correct": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
@@ -15264,6 +15699,29 @@
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
       "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
       "dev": true
+    },
+    "spdx-license-list": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/spdx-license-list/-/spdx-license-list-6.6.0.tgz",
+      "integrity": "sha512-vLwdf9AWgdJQmG8cai2HKfkInFsliKaCCOwXmdVonClIhdURTX61KdDOoXC1qcQ7gDaZj+CUTcrMJeAdnCtrKA==",
+      "dev": true
+    },
+    "spdx-ranges": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
+      "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==",
+      "dev": true
+    },
+    "spdx-satisfies": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-4.0.1.tgz",
+      "integrity": "sha512-WVzZ/cXAzoNmjCWiEluEA3BjHp5tiUmmhn9MK+X0tBbR9sOqtC6UQwmgCNrAIZvNlMuBUYAaHYfb2oqlF9SwKA==",
+      "dev": true,
+      "requires": {
+        "spdx-compare": "^1.0.0",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
     },
     "split2": {
       "version": "3.2.2",
@@ -15459,6 +15917,12 @@
         "is-number": "^7.0.0"
       }
     },
+    "treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true
+    },
     "trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -15547,6 +16011,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true
+    },
+    "util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha512-mLs5zAK+ctllYBj+iAQvlDCwoxU/WDOUaJkcFudeiAX6OajC6BKXJUa9a+tbtkC11dz2Ufb7h0lyvIOVn4LADA==",
       "dev": true
     },
     "v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   ],
   "scripts": {
     "format": "prettier \"**/*.{js,md}\" --write --cache --cache-strategy metadata --cache-location .prettiercache",
+    "license:check": "license-checker --summary --onlyAllow $(node ./licenses-allowed.js ';') > /dev/null",
+    "license:for-review": "license-checker --summary --exclude $(node ./licenses-allowed.js ',')",
+    "license:summary": "license-checker --summary",
     "lint": "eslint \"**/*.js\" --fix --cache",
     "prepare": "husky install",
     "test": "jest",
@@ -34,9 +37,11 @@
     "eslint-plugin-security": "^1.7.1",
     "husky": "^8.0.3",
     "jest": "^29.4.2",
+    "license-checker": "^25.0.1",
     "lint-staged": "^13.1.2",
     "markdownlint-cli": "^0.34.0",
     "prettier": "^2.8.4",
-    "sort-package-json": "^2.4.1"
+    "sort-package-json": "^2.4.1",
+    "spdx-license-list": "^6.6.0"
   }
 }

--- a/src/commands/generate.js
+++ b/src/commands/generate.js
@@ -143,6 +143,10 @@ module.exports = {
       stepsOfExecution.push(toolbox.dockerizeWorkflow(userInput));
     }
 
+    if (userInput.features.includes('licenseChecks')) {
+      stepsOfExecution.push(toolbox.setupLicenseChecks(userInput));
+    }
+
     if (userInput.db === 'pg') {
       stepsOfExecution.push(toolbox.setupPostgreSQL(userInput));
     }

--- a/src/extensions/generate-readme.js
+++ b/src/extensions/generate-readme.js
@@ -37,6 +37,7 @@ module.exports = (toolbox) => {
               },
             },
             openApi: isExampleApp,
+            licenseChecks: features.includes('licenseChecks'),
           },
           run: {
             build: projectLanguage === 'TS',

--- a/src/extensions/husky-setup-extension.js
+++ b/src/extensions/husky-setup-extension.js
@@ -63,6 +63,7 @@ module.exports = (toolbox) => {
               target: `${appDir}/.husky/pre-commit`,
               props: {
                 ts: projectLanguage === 'TS',
+                licenseChecks: features.includes('licenseChecks'),
                 test: {
                   unit: true,
                   e2e: true,

--- a/src/extensions/husky-setup-extension.test.js
+++ b/src/extensions/husky-setup-extension.test.js
@@ -218,6 +218,7 @@ describe('husky-setup-extension', () => {
             target: `${appDir}/.husky/pre-commit`,
             props: {
               ts: input.projectLanguage === 'TS',
+              licenseChecks: false,
               test: {
                 unit: true,
                 e2e: true,

--- a/src/extensions/setup-license-checks.js
+++ b/src/extensions/setup-license-checks.js
@@ -1,0 +1,33 @@
+'use strict';
+
+module.exports = (toolbox) => {
+  toolbox.setupLicenseChecks = ({ assetsPath, appDir, pkgJson }) => {
+    const syncOperations = () => {
+      Object.assign(pkgJson.scripts, {
+        'license:check':
+          "license-checker --summary --excludePrivatePackages --onlyAllow $(node ./licenses-allowed.js ';') > /dev/null",
+        'license:for-review':
+          "license-checker --summary --excludePrivatePackages --exclude $(node ./licenses-allowed.js ',')",
+        'license:summary': 'license-checker --summary',
+      });
+
+      Object.assign(pkgJson.devDependencies, {
+        'license-checker': '^25.0.1',
+        'spdx-license-list': '^6.6.0',
+      });
+    };
+
+    const asyncOperations = async () => {
+      await toolbox.filesystem.copyAsync(
+        `${assetsPath}/licenses/`,
+        `${appDir}/`,
+        { overwrite: true }
+      );
+    };
+
+    return {
+      syncOperations,
+      asyncOperations,
+    };
+  };
+};

--- a/src/extensions/setup-license-checks.test.js
+++ b/src/extensions/setup-license-checks.test.js
@@ -1,0 +1,86 @@
+const extend = require('./setup-license-checks');
+const {
+  createToolboxMock,
+  createExtensionInput,
+} = require('../utils/test/mocks');
+
+describe('setup-license-checks', () => {
+  let toolbox;
+
+  beforeEach(() => {
+    toolbox = createToolboxMock();
+    extend(toolbox);
+  });
+
+  it('should be defined', () => {
+    expect(extend).toBeDefined();
+  });
+
+  it('should set setupLicenseChecks on toolbox', () => {
+    expect(toolbox.setupLicenseChecks).toBeDefined();
+  });
+
+  describe('setupLicenseChecks', () => {
+    let input;
+    let ops;
+
+    beforeAll(() => {
+      input = createExtensionInput();
+    });
+
+    beforeEach(() => {
+      ops = toolbox.setupHusky(input);
+    });
+
+    it('should return syncOperations and asyncOperations when the extension is called', () => {
+      expect(ops.syncOperations).toBeDefined();
+      expect(ops.asyncOperations).toBeDefined();
+    });
+
+    describe('syncOperations', () => {
+      let scripts;
+      let devDependencies;
+
+      beforeEach(() => {
+        toolbox.setupLicenseChecks(input).syncOperations();
+        scripts = input.pkgJson.scripts;
+        devDependencies = input.pkgJson.devDependencies;
+      });
+
+      it('should add a license:check script', () => {
+        expect(scripts).toHaveProperty('license:check');
+      });
+
+      it('should add a license:for-review script', () => {
+        expect(scripts).toHaveProperty('license:for-review');
+      });
+
+      it('should add a license:summary script', () => {
+        expect(scripts).toHaveProperty('license:summary');
+      });
+
+      it('should add license-checker to devDependencies', () => {
+        expect(devDependencies).toHaveProperty('license-checker');
+      });
+
+      it('should add spdx-license-list devDependencies', () => {
+        expect(devDependencies).toHaveProperty('spdx-license-list');
+      });
+    });
+
+    describe('asyncOperations', () => {
+      beforeEach(async () => {
+        toolbox.filesystem.copyAsync = jest.fn(() => {});
+        await toolbox.setupLicenseChecks(input).asyncOperations();
+      });
+
+      it('should copy the licenses assets dir', () => {
+        expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+          `${input.assetsPath}/licenses/`,
+          `${input.appDir}/`,
+          { overwrite: true }
+        );
+      });
+    });
+  });
+});

--- a/src/templates/README.md.ejs
+++ b/src/templates/README.md.ejs
@@ -272,6 +272,46 @@ If you're experiencing issues setting this up, checkout the troubleshooting
 section at the bottom.
 <% } -%>
 
+<% if (props.setup.licenseChecks) { -%>
+## Working with Licenses
+
+Whenever a new `npm` module is added to the project we need to check its
+license. If the license is included in the
+[OSI approved license list](https://opensource.org/licenses/), then we
+can use it. If not - we need to review it manually. Start by running
+the following `npm` script:
+
+```bash
+npm run license:check
+```
+
+If the script succeeds, that means that the license is either a included
+in the OSI list, or it was already reviewed and passed the review. When
+the script fails it will print the first license that neeeds a review.
+In order to list all licenses that need a review run the following:
+
+```bash
+npm run license:for-review
+```
+
+In order to verify that a license suits your case, you can use a website like
+[SOOS](https://app.soos.io/research/licenses). Find the licesnce and inspect
+the `Usage` and `Requirements` sections. You need to verify that the license
+is `permissive`. Look for things like whether the license allows for
+`Commercial Use` and `Private Use`.
+
+If the package passes the review, then include it in the list in
+`licenses-reviewed.js` located in the root of ths project.
+
+If the package does not pass the review, then look for an alternative package.
+
+Lastly, if you just want to print a summary of all license, run:
+
+```bash
+npm run license:summary
+```
+<% } -%>
+
 <% if (props.debug.vscode) { -%>
 ## Debug
 

--- a/src/templates/husky/pre-commit.ejs
+++ b/src/templates/husky/pre-commit.ejs
@@ -4,6 +4,7 @@
 <% if (props.ts) { %>npx --no -- tsc --noEmit<% } %>
 npx --no -- lint-staged
 npx --no -- ls-lint
+<% if (props.licenseChecks) { %>npm run license:check<% } %>
 <% if (props.test.unit) { %>npm run test:cov<% } %>
 <% if (props.test.e2e) { %>npm run test:e2e:cov<% } %>
 scripts/detect-secrets.sh

--- a/src/utils/commands/features.js
+++ b/src/utils/commands/features.js
@@ -5,4 +5,5 @@ module.exports = [
   'preCommit',
   'prePush',
   'dockerizeWorkflow',
+  'licenseChecks',
 ];

--- a/src/utils/commands/questions.js
+++ b/src/utils/commands/questions.js
@@ -13,9 +13,13 @@ const featureChoices = [
     message: 'Containerization with Docker',
     value: 'dockerizeWorkflow',
   },
+  {
+    message: 'Dependency License Checks',
+    value: 'licenseChecks',
+  },
 ];
 
-const initialFeatureChoices = [0, 1, 5];
+const initialFeatureChoices = [0, 1, 5, 6];
 
 const getQuestions = (projectName, pickedFramework) => [
   {

--- a/src/utils/test/mocks.js
+++ b/src/utils/test/mocks.js
@@ -120,6 +120,10 @@ const createToolboxMock = () => ({
   editorconfig: () => ({
     asyncOperations: async () => {},
   }),
+  setupLicenseChecks: () => ({
+    syncOperations: () => {},
+    asyncOperations: async () => {},
+  }),
 });
 
 const createExtensionInput = () => ({
@@ -137,6 +141,7 @@ const createExtensionInput = () => ({
     'preCommit',
     'prePush',
     'dockerizeWorkflow',
+    'licenseChecks',
   ],
   pkgJson: {
     scripts: {},


### PR DESCRIPTION
An attempt at implementing license checks. Licenses are taken from the [SPDX list](https://spdx.org/licenses/) and the [OSI licenses](https://opensource.org/licenses/) are used as a baseline. Any license that's not in the baseline should be reviewed. If the license can be used should be added to a file `reviewed-licenses.json` which will be added to the baseline.

Added the following:
- [x] `license:summary` script - just a shortcut for the underlying `npm` module - `npx license-checker --summary`
- [x] `license:check` script - fails if a license is found that's not in the baseline
- [x] `license:for-review` script - lists all licences causing `license:check` to fail
- [x] `README.md` section with instructions 
