### PR TITLE
refactor: change zod-to-openapi with zod-openapi

### DIFF
--- a/assets/express/example-app/scripts/generate-openapi.ts
+++ b/assets/express/example-app/scripts/generate-openapi.ts
@@ -7,21 +7,22 @@ import { resolve } from 'path';
 import { envSchema } from '@common/environment';
 import { routes } from '@api';
 import { RouteDefinition } from '@common/api';
-import { getDocumentGenerator } from '@common/openapi';
+import { generateDocument } from '@common/openapi';
 
 const run = async () => {
   const env = Object.freeze(envSchema.parse(process.env));
 
-  const generator = getDocumentGenerator('3.0.3', routes as RouteDefinition[]);
-
-  const document = generator.generateDocument({
+  const document = generateDocument({
+    version: '3.0.3',
     info: {
       version: '1.0.0',
       title: 'To-Do',
       description: 'A To-Do application API',
     },
-    servers: [{ url: `http://localhost:${env.PORT}` }],
+    routes: routes as RouteDefinition[],
   });
+
+  document.servers = [{ url: `http://localhost:${env.PORT}` }];
 
   const file = resolve(__dirname, '..', '.openapi', 'openapi.json');
   const data = JSON.stringify(document, null, 2);

--- a/assets/express/example-app/src/api/auth/dto/jwt-tokens.dto.ts
+++ b/assets/express/example-app/src/api/auth/dto/jwt-tokens.dto.ts
@@ -1,3 +1,3 @@
 import { jwtTokens } from '@common/data/auth';
 
-export const jwtTokensDTO = jwtTokens.openapi({ refId: 'JwtTokens' });
+export const jwtTokensDTO = jwtTokens.openapi({ ref: 'JwtTokens' });

--- a/assets/express/example-app/src/api/auth/routes/login.route.ts
+++ b/assets/express/example-app/src/api/auth/routes/login.route.ts
@@ -14,7 +14,7 @@ export default defineRoute({
   },
   responses: {
     200: jwtTokensDTO,
-    422: response.UnprocessableEntity('Invalid email or password'),
+    422: response.UnprocessableEntity,
   },
 }).attachHandler(
   asyncHandler(async ({ body, services }, res) => {

--- a/assets/express/example-app/src/api/auth/routes/register.route.ts
+++ b/assets/express/example-app/src/api/auth/routes/register.route.ts
@@ -13,8 +13,8 @@ export default defineRoute({
   },
   responses: {
     200: jwtTokensDTO,
-    409: response.Conflict(),
-    422: response.UnprocessableEntity(),
+    409: response.Conflict,
+    422: response.UnprocessableEntity,
   },
 }).attachHandler(
   asyncHandler(async ({ body, services }, res) => {

--- a/assets/express/example-app/src/api/v1/todos/dto/todo.dto.ts
+++ b/assets/express/example-app/src/api/v1/todos/dto/todo.dto.ts
@@ -1,3 +1,3 @@
 import { todo as todoSchema } from '@common/data/models';
 
-export const todoDTO = todoSchema.openapi({ refId: 'Todo' });
+export const todoDTO = todoSchema.openapi({ ref: 'Todo' });

--- a/assets/express/example-app/src/api/v1/todos/routes/create.route.ts
+++ b/assets/express/example-app/src/api/v1/todos/routes/create.route.ts
@@ -14,8 +14,8 @@ export default defineRoute({
   },
   responses: {
     201: todoDTO,
-    401: response.Unauthorized(),
-    422: response.UnprocessableEntity(),
+    401: response.Unauthorized,
+    422: response.UnprocessableEntity,
   },
 }).attachHandler(
   asyncHandler(async ({ body, services, auth: { sub } }, res) => {

--- a/assets/express/example-app/src/api/v1/todos/routes/delete.route.ts
+++ b/assets/express/example-app/src/api/v1/todos/routes/delete.route.ts
@@ -13,10 +13,10 @@ export default defineRoute({
     params: todoIdDTO,
   },
   responses: {
-    204: response.NoContent(),
-    401: response.Unauthorized(),
-    404: response.NotFound(),
-    422: response.UnprocessableEntity(),
+    204: response.NoContent,
+    401: response.Unauthorized,
+    404: response.NotFound,
+    422: response.UnprocessableEntity,
   },
 }).attachHandler(
   asyncHandler(async ({ params, services, auth: { sub } }, res) => {

--- a/assets/express/example-app/src/api/v1/todos/routes/get.route.ts
+++ b/assets/express/example-app/src/api/v1/todos/routes/get.route.ts
@@ -14,9 +14,9 @@ export default defineRoute({
   },
   responses: {
     200: todoDTO,
-    401: response.Unauthorized(),
-    404: response.NotFound(),
-    422: response.UnprocessableEntity(),
+    401: response.Unauthorized,
+    404: response.NotFound,
+    422: response.UnprocessableEntity,
   },
 }).attachHandler(
   asyncHandler(async ({ services, params, auth: { sub } }, res) => {

--- a/assets/express/example-app/src/api/v1/todos/routes/list.route.ts
+++ b/assets/express/example-app/src/api/v1/todos/routes/list.route.ts
@@ -14,7 +14,7 @@ export default defineRoute({
     query: todoQueryDTO,
   },
   responses: {
-    401: response.Unauthorized(),
+    401: response.Unauthorized,
     200: paginated(todoDTO),
   },
 }).attachHandler(

--- a/assets/express/example-app/src/api/v1/todos/routes/update.route.ts
+++ b/assets/express/example-app/src/api/v1/todos/routes/update.route.ts
@@ -15,9 +15,9 @@ export default defineRoute({
   },
   responses: {
     200: todoDTO,
-    401: response.Unauthorized(),
-    404: response.NotFound(),
-    422: response.UnprocessableEntity(),
+    401: response.Unauthorized,
+    404: response.NotFound,
+    422: response.UnprocessableEntity,
   },
 }).attachHandler(
   asyncHandler(async ({ body, params, services, auth: { sub } }, res) => {

--- a/assets/express/example-app/src/common/api/handler.ts
+++ b/assets/express/example-app/src/common/api/handler.ts
@@ -1,13 +1,10 @@
-import { RouteConfig } from '@asteasolutions/zod-to-openapi';
 import {
   RequestHandler as ExpressRequestHandler,
   ErrorRequestHandler as ExpressErrorHandler,
 } from 'express';
 import { AnyZodObject, z } from 'zod';
 
-type Request = NonNullable<RouteConfig['request']>;
-
-export type RequestKey = keyof Request;
+export type RequestKey = 'params' | 'query' | 'headers' | 'body';
 
 export type RequestSchema<
   Params extends AnyZodObject = AnyZodObject,

--- a/assets/express/example-app/src/common/api/response.test.ts
+++ b/assets/express/example-app/src/common/api/response.test.ts
@@ -4,7 +4,7 @@ import { response } from './response';
 describe('response', () => {
   describe('NoContent', () => {
     it('should be an OpenAPI response without content', () => {
-      const noContent = response.NoContent();
+      const noContent = response.NoContent;
       expect(noContent).toHaveProperty('description');
       expect(noContent).not.toHaveProperty('content');
     });
@@ -12,7 +12,7 @@ describe('response', () => {
 
   describe('NotFound', () => {
     it('should return a zod schema for an error', () => {
-      const schema = response.NotFound();
+      const schema = response.NotFound;
       expect(schema).toBeInstanceOf(ZodObject);
       expect(schema.shape.message).toBeInstanceOf(ZodString);
       const error = { message: 'error' };
@@ -22,7 +22,7 @@ describe('response', () => {
 
   describe('Conflict', () => {
     it('should return a zod schema for an error', () => {
-      const schema = response.Conflict();
+      const schema = response.Conflict;
       expect(schema).toBeInstanceOf(ZodObject);
       expect(schema.shape.message).toBeInstanceOf(ZodString);
       const error = { message: 'error' };
@@ -32,7 +32,7 @@ describe('response', () => {
 
   describe('UnprocessableEntity', () => {
     it('should return a zod schema for an error', () => {
-      const schema = response.UnprocessableEntity();
+      const schema = response.UnprocessableEntity;
       expect(schema).toBeInstanceOf(ZodObject);
       expect(schema.shape.message).toBeInstanceOf(ZodString);
       const error = { message: 'error', errors: [] };
@@ -42,7 +42,7 @@ describe('response', () => {
 
   describe('Unauthorized', () => {
     it('should return a zod schema for an error', () => {
-      const schema = response.Unauthorized();
+      const schema = response.Unauthorized;
       expect(schema).toBeInstanceOf(ZodObject);
       expect(schema.shape.message).toBeInstanceOf(ZodString);
       const error = { message: 'error' };

--- a/assets/express/example-app/src/common/api/response.ts
+++ b/assets/express/example-app/src/common/api/response.ts
@@ -13,15 +13,11 @@ const zodErrorIssue = z.object({
 });
 
 export const response = {
-  NoContent: () => ({ description: httpStatuses.message[204] as string }),
-  NotFound: (message = 'Record not found') =>
-    error(message).openapi({ refId: 'NotFound' }),
-  Conflict: (message = 'Record already exists') =>
-    error(message).openapi({ refId: 'Conflict' }),
-  UnprocessableEntity: (message = 'Invalid input') =>
-    error(message)
-      .extend({ errors: z.array(zodErrorIssue) })
-      .openapi({ refId: 'UnprocessableEntity' }),
-  Unauthorized: (message = 'Unauthorized') =>
-    error(message).openapi({ refId: 'Unauthorized' }),
+  NoContent: { description: httpStatuses.message[204] as string },
+  Unauthorized: error('Unauthorized').openapi({ ref: 'Unauthorized' }),
+  NotFound: error('Record not found').openapi({ ref: 'NotFound' }),
+  Conflict: error('Record already exists').openapi({ ref: 'Conflict' }),
+  UnprocessableEntity: error('Invalid input')
+    .extend({ errors: z.array(zodErrorIssue) })
+    .openapi({ ref: 'UnprocessableEntity' }),
 };

--- a/assets/express/example-app/src/common/api/route.ts
+++ b/assets/express/example-app/src/common/api/route.ts
@@ -1,16 +1,18 @@
-import { ResponseConfig, RouteConfig } from '@asteasolutions/zod-to-openapi';
+import { ZodOpenApiResponseObject } from 'zod-openapi';
 import { RequestSchema, RequestHandler } from './handler';
 import { RequestHandler as ExpressRequestHandler } from 'express';
 import { AnyZodObject } from 'zod';
 
-type Responses = { [statusCode: string]: ResponseConfig | AnyZodObject };
+type Responses = {
+  [statusCode: string]: ZodOpenApiResponseObject | AnyZodObject;
+};
 
 export type RouteDefinition<S extends RequestSchema = RequestSchema> = {
   operationId: string;
   summary?: string;
   description?: string;
   tags?: string[];
-  method: RouteConfig['method'];
+  method: 'get' | 'put' | 'post' | 'delete' | 'patch';
   path: string;
   authenticate?: boolean;
   request?: S;

--- a/assets/express/example-app/src/common/openapi.test.ts
+++ b/assets/express/example-app/src/common/openapi.test.ts
@@ -1,7 +1,7 @@
 import z from 'zod';
-import { getDocumentGenerator, reformatPathParams } from './openapi';
+import { generateDocument, reformatPathParams } from './openapi';
 import { response, RouteDefinition } from '@common/api';
-import { OpenAPIGenerator } from '@asteasolutions/zod-to-openapi';
+import { ZodOpenApiRequestBodyObject } from 'zod-openapi';
 
 describe('reformatPathParams', () => {
   it('should change the format of the path params', () => {
@@ -11,244 +11,168 @@ describe('reformatPathParams', () => {
   });
 });
 
-describe('getDocumentGenerator', () => {
-  it('should return an OpenAPI generator', () => {
-    const generator = getDocumentGenerator('3.0.3', []);
-    expect(generator).toBeInstanceOf(OpenAPIGenerator);
-  });
-
-  describe('document', () => {
-    const route: RouteDefinition = {
-      operationId: 'route-id',
-      summary: 'Does something',
-      description: 'It does somehting',
-      tags: ['tag'],
-      method: 'post',
-      path: '/users/:id',
-      handler: (_req, res) => {
-        res.send('OK');
-      },
-      responses: {
-        200: {
-          description: 'OK',
-          content: {
-            'application/json': {
-              schema: {
-                type: 'object',
-                properties: {
-                  name: {
-                    type: 'string',
-                    example: 'Laundry',
-                  },
+describe('generateDocument', () => {
+  const route: RouteDefinition = {
+    operationId: 'route-id',
+    summary: 'Does something',
+    description: 'It does somehting',
+    tags: ['tag'],
+    method: 'post',
+    path: '/users/:id',
+    handler: (_req, res) => {
+      res.send('OK');
+    },
+    responses: {
+      200: {
+        description: 'OK',
+        content: {
+          'application/json': {
+            schema: {
+              type: 'object',
+              properties: {
+                name: {
+                  type: 'string',
+                  example: 'Laundry',
                 },
-                required: ['name'],
               },
+              required: ['name'],
             },
           },
         },
       },
+    },
+  };
+
+  it('should define bearer token authentication', () => {
+    const document = generateDocument({
+      version: '3.0.3',
+      info: {
+        title: 'My API',
+        version: '1.0.0',
+      },
+      routes: [],
+    });
+
+    expect(document.components?.securitySchemes?.bearerAuth).toEqual({
+      type: 'http',
+      scheme: 'bearer',
+      bearerFormat: 'JWT',
+    });
+  });
+
+  describe('when the route requires authentication', () => {
+    const routeWithAuth: RouteDefinition = {
+      ...route,
+      authenticate: true,
     };
 
-    it('should define bearer token authentication', () => {
-      const generator = getDocumentGenerator('3.0.3', []);
-      const document = generator.generateDocument({
-        info: { title: 'My API', version: '1.0.0' },
+    it('should add security definitions', () => {
+      const document = generateDocument({
+        version: '3.0.3',
+        info: {
+          title: 'My API',
+          version: '1.0.0',
+        },
+        routes: [routeWithAuth],
       });
-      expect(document.components?.securitySchemes?.bearerAuth).toEqual({
-        type: 'http',
-        scheme: 'bearer',
-        bearerFormat: 'JWT',
-      });
-    });
 
-    it('should not register a schema twice', () => {
-      const route1 = {
+      const definition =
+        document?.paths?.[reformatPathParams(route.path)][route.method];
+
+      expect(definition?.security).toEqual([
+        {
+          bearerAuth: [],
+        },
+      ]);
+    });
+  });
+
+  describe('when a route has responses schemas', () => {
+    it('should not try to convert non-zod response schemas', () => {
+      const routeWithJsonSchemaResponse: RouteDefinition = {
         ...route,
-        request: {
-          query: z.object({ name: z.string() }).openapi({ refId: 'TheSchema' }),
+        responses: {
+          204: response.NoContent,
         },
       };
-      const route2 = {
+
+      const document = generateDocument({
+        version: '3.0.3',
+        info: {
+          title: 'My API',
+          version: '1.0.0',
+        },
+        routes: [routeWithJsonSchemaResponse],
+      });
+
+      const definition =
+        document?.paths?.[reformatPathParams(route.path)][route.method];
+
+      expect(definition?.responses['204']).toEqual({
+        description: 'No Content',
+      });
+    });
+
+    it('should map zod schemas to application/json content schemas', () => {
+      const routeWithJsonSchemaResponse: RouteDefinition = {
         ...route,
         request: {
-          query: z.object({ age: z.number() }).openapi({ refId: 'TheSchema' }),
+          body: z.object({
+            id: z.number().int(),
+            name: z.string(),
+          }),
+        },
+        responses: {
+          200: z.object({
+            id: z.number().int(),
+            name: z.string(),
+          }),
         },
       };
 
-      const generator = getDocumentGenerator('3.0.3', [route1, route2]);
-      const document = generator.generateDocument({
-        info: { title: 'My API', version: '1.0.0' },
+      const document = generateDocument({
+        version: '3.0.3',
+        info: {
+          title: 'My API',
+          version: '1.0.0',
+        },
+        routes: [routeWithJsonSchemaResponse],
       });
 
-      const schema = document.components?.schemas?.['TheSchema'] as never as {
-        properties: Record<string, unknown>;
-      };
+      const definition =
+        document?.paths?.[reformatPathParams(route.path)][route.method];
 
-      expect(schema.properties.name).toEqual({ type: 'string' });
-      expect(schema.properties.age).not.toBeDefined();
+      expect(
+        (definition?.requestBody as ZodOpenApiRequestBodyObject)['content']
+      ).toHaveProperty('application/json');
+      expect(definition?.responses['200'].content).toHaveProperty(
+        'application/json'
+      );
     });
 
-    describe('when the route requires authentication', () => {
-      const routeWithAuth: RouteDefinition = {
+    it('should provide a default description when one is not available for the status code', () => {
+      const routeWithDefaultDescription: RouteDefinition = {
         ...route,
-        authenticate: true,
+        responses: {
+          1234: z.object({}),
+        },
       };
 
-      it('should add security definitions', () => {
-        const generator = getDocumentGenerator('3.0.3', [routeWithAuth]);
-        const document = generator.generateDocument({
-          info: { title: 'My API', version: '1.0.0' },
-        });
-
-        const definition =
-          document.paths[reformatPathParams(route.path)][route.method];
-
-        expect(definition.security).toEqual([
-          {
-            bearerAuth: [],
-          },
-        ]);
-      });
-    });
-
-    describe('when the route has a request schema', () => {
-      describe('with a named query schema', () => {
-        const routeWithQuery: RouteDefinition = {
-          ...route,
-          request: {
-            query: z.object({ name: z.string() }).openapi({ refId: 'Query' }),
-          },
-        };
-
-        it('should register it', () => {
-          const generator = getDocumentGenerator('3.0.3', [routeWithQuery]);
-          const document = generator.generateDocument({
-            info: { title: 'My API', version: '1.0.0' },
-          });
-          expect(document.components?.schemas).toHaveProperty('Query');
-        });
+      const document = generateDocument({
+        version: '3.0.3',
+        info: {
+          title: 'My API',
+          version: '1.0.0',
+        },
+        routes: [routeWithDefaultDescription],
       });
 
-      describe('with a named params schema', () => {
-        const routeWithParams: RouteDefinition = {
-          ...route,
-          request: {
-            params: z
-              .object({ id: z.coerce.number() })
-              .openapi({ refId: 'Params' }),
-          },
-        };
+      const definition =
+        document?.paths?.[reformatPathParams(route.path)][route.method];
 
-        it('should register it', () => {
-          const generator = getDocumentGenerator('3.0.3', [routeWithParams]);
-          const document = generator.generateDocument({
-            info: { title: 'My API', version: '1.0.0' },
-          });
-          expect(document.components?.schemas).toHaveProperty('Params');
-        });
-      });
-
-      describe('with a named headers schema', () => {
-        const routeWithHeaders: RouteDefinition = {
-          ...route,
-          request: {
-            headers: z
-              .object({ accept: z.string() })
-              .openapi({ refId: 'Headers' }),
-          },
-        };
-
-        it('should register it', () => {
-          const generator = getDocumentGenerator('3.0.3', [routeWithHeaders]);
-          const document = generator.generateDocument({
-            info: { title: 'My API', version: '1.0.0' },
-          });
-          expect(document.components?.schemas).toHaveProperty('Headers');
-        });
-      });
-
-      describe('with a named body schema', () => {
-        const routeWithBody: RouteDefinition = {
-          ...route,
-          request: {
-            body: z.object({ name: z.string() }).openapi({ refId: 'Body' }),
-          },
-        };
-
-        it('should register it', () => {
-          const generator = getDocumentGenerator('3.0.3', [routeWithBody]);
-          const document = generator.generateDocument({
-            info: { title: 'My API', version: '1.0.0' },
-          });
-          expect(document.components?.schemas).toHaveProperty('Body');
-        });
-      });
-    });
-
-    describe('when a route has responses schemas', () => {
-      it('should not try to convert non-zod response schemas', () => {
-        const routeWithJsonSchemaResponse: RouteDefinition = {
-          ...route,
-          responses: {
-            204: response.NoContent(),
-          },
-        };
-
-        const generator = getDocumentGenerator('3.0.3', [
-          routeWithJsonSchemaResponse,
-        ]);
-        const document = generator.generateDocument({
-          info: { title: 'My API', version: '1.0.0' },
-        });
-
-        const definition =
-          document.paths[reformatPathParams(route.path)][route.method];
-
-        expect(definition.responses['204']).toEqual({
-          description: 'No Content',
-        });
-      });
-
-      it('should register them', () => {
-        const routeWithNamedResponse: RouteDefinition = {
-          ...route,
-          responses: {
-            204: z.object({ name: z.string() }).openapi({ refId: 'Todo' }),
-          },
-        };
-
-        const generator = getDocumentGenerator('3.0.3', [
-          routeWithNamedResponse,
-        ]);
-        const document = generator.generateDocument({
-          info: { title: 'My API', version: '1.0.0' },
-        });
-
-        expect(document.components?.schemas).toHaveProperty('Todo');
-      });
-
-      it('should provide a default description when one is not available for the status code', () => {
-        const routeWithDefaultDescription: RouteDefinition = {
-          ...route,
-          responses: {
-            1234: z.object({}),
-          },
-        };
-
-        const generator = getDocumentGenerator('3.0.3', [
-          routeWithDefaultDescription,
-        ]);
-        const document = generator.generateDocument({
-          info: { title: 'My API', version: '1.0.0' },
-        });
-
-        const definition =
-          document.paths[reformatPathParams(route.path)][route.method];
-
-        expect(definition.responses['1234'].description).toBe(
-          'Unknown response code'
-        );
-      });
+      expect(definition?.responses['1234'].description).toBe(
+        'Unknown response code'
+      );
     });
   });
 });

--- a/assets/express/example-app/src/common/openapi.ts
+++ b/assets/express/example-app/src/common/openapi.ts
@@ -1,9 +1,10 @@
-import { ZodObject, ZodType } from 'zod';
+import { ZodType } from 'zod';
 import {
-  OpenAPIGenerator,
-  OpenAPIRegistry,
-} from '@asteasolutions/zod-to-openapi';
-import { OpenApiVersion } from '@asteasolutions/zod-to-openapi/dist/openapi-generator';
+  ZodOpenApiVersion,
+  createDocument,
+  ZodOpenApiObject,
+  ZodOpenApiPathsObject,
+} from 'zod-openapi';
 import { RouteDefinition } from '@common/api';
 import httpStatuses from 'statuses';
 
@@ -11,168 +12,78 @@ import httpStatuses from 'statuses';
 export const reformatPathParams = (path: string) =>
   path.replaceAll(/:[a-zA-Z]+/g, (match) => `{${match.substring(1)}}`);
 
-const registerRoute = (
-  registry: OpenAPIRegistry,
-  { path, request, responses, ...route }: RouteDefinition
-) => {
-  registry.registerPath({
-    operationId: route.operationId,
-    summary: route.summary,
-    description: route.description,
-    tags: route.tags,
-    method: route.method,
-    path: reformatPathParams(path),
-    ...(route.authenticate && {
-      security: [
-        {
-          bearerAuth: [],
-        },
-      ],
-    }),
-    ...(request && {
-      request: {
-        params: request.params,
-        query: request.query,
-        headers: request.headers,
-        ...(request.body && {
-          body: {
-            content: {
-              'application/json': {
-                schema: request.body,
-              },
-            },
-          },
-        }),
+const mapRouteToPath = ({ request, responses, ...route }: RouteDefinition) => ({
+  operationId: route.operationId,
+  summary: route.summary,
+  description: route.description,
+  tags: route.tags,
+  ...(route.authenticate && {
+    security: [
+      {
+        bearerAuth: [],
       },
-    }),
-    responses: Object.fromEntries(
-      Object.entries(responses).map(([code, schema]) => [
-        code,
-        schema instanceof ZodType
-          ? {
-              description:
-                httpStatuses.message[code as never as number] ??
-                'Unknown response code',
-              content: { 'application/json': { schema } },
-            }
-          : schema,
-      ])
-    ),
-  });
-};
+    ],
+  }),
+  ...(request && {
+    requestParams: {
+      path: request.params,
+      query: request.query,
+      header: request.headers,
+    },
+  }),
+  ...(request?.body && {
+    requestBody: {
+      content: {
+        'application/json': {
+          schema: request.body,
+        },
+      },
+    },
+  }),
+  responses: Object.fromEntries(
+    Object.entries(responses).map(([code, schema]) => [
+      code,
+      schema instanceof ZodType
+        ? {
+            description:
+              httpStatuses.message[code as never as number] ??
+              'Unknown response code',
+            content: { 'application/json': { schema } },
+          }
+        : schema,
+    ])
+  ),
+});
 
-const getRefId = <Schema extends ZodType>(schema: Schema) =>
-  schema._def.openapi?.metadata?.refId;
+export const mapRoutesToPaths = (routes: RouteDefinition[]) =>
+  routes.reduce((paths, route) => {
+    const path = reformatPathParams(route.path);
+    paths[path] ||= {};
+    paths[path][route.method] = mapRouteToPath(route);
+    return paths;
+  }, {} as ZodOpenApiPathsObject);
 
-const registerSchema = <Schema extends ZodType>(
-  registry: OpenAPIRegistry,
-  registeredSchemas: Map<string, ZodType>,
-  schema: Schema
-): Schema => {
-  if (schema instanceof ZodObject) {
-    for (const [k, v] of Object.entries(schema.shape)) {
-      schema.shape[k] = registerSchema(
-        registry,
-        registeredSchemas,
-        v as ZodType
-      );
-    }
-  }
-
-  const refId = getRefId(schema);
-
-  if (!refId) {
-    return schema;
-  }
-
-  if (registeredSchemas.has(refId)) {
-    return registeredSchemas.get(refId) as Schema;
-  }
-
-  const registeredSchema = registry.register(refId, schema);
-  registeredSchemas.set(refId, registeredSchema);
-  return registeredSchema;
-};
-
-const registerRoutes = (
-  registry: OpenAPIRegistry,
-  routes: RouteDefinition[]
-) => {
-  const registeredSchemas = new Map<string, ZodType>();
-
-  for (const route of routes) {
-    if (route.request?.body) {
-      route.request.body = registerSchema(
-        registry,
-        registeredSchemas,
-        route.request.body
-      );
-    }
-
-    if (route.request?.query) {
-      route.request.query = registerSchema(
-        registry,
-        registeredSchemas,
-        route.request.query
-      );
-    }
-
-    if (route.request?.params) {
-      route.request.params = registerSchema(
-        registry,
-        registeredSchemas,
-        route.request.params
-      );
-    }
-
-    if (route.request?.headers) {
-      route.request.headers = registerSchema(
-        registry,
-        registeredSchemas,
-        route.request.headers
-      );
-    }
-
-    for (const [code, response] of Object.entries(route.responses)) {
-      if (response instanceof ZodObject) {
-        route.responses[code] = registerSchema(
-          registry,
-          registeredSchemas,
-          response
-        );
-      }
-    }
-
-    registerRoute(registry, route);
-  }
-};
-
-export const getDocumentGenerator = (
+export const generateDocument = ({
+  version,
+  info,
+  routes,
+}: {
   // 3.1.0 is not yet supported by our version of swagger-ui
-  version: Exclude<OpenApiVersion, '3.1.0'>,
-  routes: RouteDefinition[]
-) => {
-  const registry = new OpenAPIRegistry();
-
-  registry.registerComponent('securitySchemes', 'bearerAuth', {
-    type: 'http',
-    scheme: 'bearer',
-    bearerFormat: 'JWT',
+  version: Exclude<ZodOpenApiVersion, '3.1.0'>;
+  info: ZodOpenApiObject['info'];
+  routes: RouteDefinition[];
+}) =>
+  createDocument({
+    openapi: version,
+    info,
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: 'http',
+          scheme: 'bearer',
+          bearerFormat: 'JWT',
+        },
+      },
+    },
+    paths: mapRoutesToPaths(routes),
   });
-
-  registerRoutes(registry, routes);
-
-  for (const def of registry.definitions) {
-    if (def.type !== 'schema') {
-      continue;
-    }
-
-    const meta = def.schema._def?.openapi?.metadata;
-
-    if (meta) {
-      delete meta.refId;
-    }
-  }
-
-  return new OpenAPIGenerator(registry.definitions, version);
-};

--- a/assets/express/example-app/src/extensions/zod/index.ts
+++ b/assets/express/example-app/src/extensions/zod/index.ts
@@ -1,15 +1,9 @@
 import z from 'zod';
-import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
+import { extendZodWithOpenApi } from 'zod-openapi';
 
 declare module 'zod' {
   interface ZodNumber {
     coerce(): ZodNumber;
-  }
-}
-
-declare module '@asteasolutions/zod-to-openapi' {
-  interface ZodOpenAPIMetadata {
-    refId?: string;
   }
 }
 

--- a/src/extensions/install-framework.js
+++ b/src/extensions/install-framework.js
@@ -83,7 +83,7 @@ module.exports = (toolbox) => {
         'query-types': '^0.1.4',
         statuses: '^2.0.1',
         zod: '^3.20.6',
-        '@asteasolutions/zod-to-openapi': '^4.4.0',
+        'zod-openapi': '^2.2.2',
       });
 
       Object.assign(pkgJson.devDependencies, {

--- a/src/extensions/install-framework.test.js
+++ b/src/extensions/install-framework.test.js
@@ -201,8 +201,8 @@ describe('install-framework', () => {
         expect(dependencies).toHaveProperty('zod');
       });
 
-      it('should add @asteasolutions/zod-to-openapi to dependencies', () => {
-        expect(dependencies).toHaveProperty('@asteasolutions/zod-to-openapi');
+      it('should add zod-openapi to dependencies', () => {
+        expect(dependencies).toHaveProperty('zod-openapi');
       });
 
       it('should add @types/cors to devDependencies', () => {


### PR DESCRIPTION
- [x] utilize schema auto-registration from `zod-openapi`
- [x] fix error response definitions pretending to be able to support custom messages 