### PR TITLE
fix: unify commitlint and commitzen config

### DIFF
--- a/assets/.commitlintrc.js
+++ b/assets/.commitlintrc.js
@@ -1,23 +1,6 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
-  rules: {
-    'type-enum': [
-      2,
-      'always',
-      [
-        'chore',
-        'feat',
-        'fix',
-        'docs',
-        'style',
-        'refactor',
-        'test',
-        'revert',
-        'ci',
-      ],
-    ],
-    'subject-case': [2, 'always', ['lower-case', 'sentence-case']],
-  },
+  rules: {},
   parserPreset: {
     parserOpts: {
       referenceActions: null,


### PR DESCRIPTION
Looks like commit zen and commit lint are configured separately, so unless you're using the defaults you're going to have conflicting configurations. In our case the type and subject case were changed, but commit zen doesn't know about it.

There's an open issue about it since 2020, so it doesn't look like things will change: https://github.com/commitizen/cz-cli/issues/740

Alternatively, we can use the [CLI provided by commit lint itself](https://commitlint.js.org/#/guides-use-prompt?id=guide-use-prompt)