### PR TITLE
refactor(ls-lint): separate configs for basic and example apps

### DIFF
--- a/assets/express/example-app/.ls-lint.yml
+++ b/assets/express/example-app/.ls-lint.yml
@@ -10,6 +10,10 @@ ls:
   .js: regex:([a-z]+)([a-z0-9]*)([-.][a-z0-9]+)*
   .ts: regex:([a-z]+)([a-z0-9]*)([-.][a-z0-9]+)*
 
+  # migrations
+  src/modules/database/migrations:
+    .ts: snake_case
+
 # ignored directories and files
 ignore:
   - node_modules
@@ -21,3 +25,5 @@ ignore:
   - .commitlintrc.js
   - .eslintrc.js
   - .prettierrc.js
+  - .openapi
+  - src/@types

--- a/src/extensions/husky-setup-extension.js
+++ b/src/extensions/husky-setup-extension.js
@@ -7,6 +7,7 @@ module.exports = (toolbox) => {
     features,
     pkgJson,
     projectLanguage,
+    isExampleApp,
   }) => {
     const {
       filesystem: { dir, copyAsync, read, writeAsync },
@@ -71,7 +72,12 @@ module.exports = (toolbox) => {
               run(`chmod +x ${appDir}/.husky/pre-commit`);
             }),
             writeAsync(`${appDir}/.lintstagedrc`, lintstagedrcData),
-            copyAsync(`${assetsPath}/.ls-lint.yml`, `${appDir}/.ls-lint.yml`),
+            copyAsync(
+              isExampleApp
+                ? `${assetsPath}/express/example-app/.ls-lint.yml`
+                : `${assetsPath}/.ls-lint.yml`,
+              `${appDir}/.ls-lint.yml`
+            ),
             copyAsync(
               `${assetsPath}/.pre-commit-config.yaml`,
               `${appDir}/.pre-commit-config.yaml`

--- a/src/extensions/husky-setup-extension.test.js
+++ b/src/extensions/husky-setup-extension.test.js
@@ -244,6 +244,23 @@ describe('husky-setup-extension', () => {
           );
         });
 
+        describe('and it is the example app', () => {
+          beforeAll(() => {
+            input.isExampleApp = true;
+          });
+
+          afterAll(() => {
+            input.isExampleApp = false;
+          });
+
+          it('should copy the example app ls-lint config', () => {
+            expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
+              `${assetsPath}/express/example-app/.ls-lint.yml`,
+              `${appDir}/.ls-lint.yml`
+            );
+          });
+        });
+
         it('should copy the pre-commit config', () => {
           expect(toolbox.filesystem.copyAsync).toHaveBeenCalledWith(
             `${assetsPath}/.pre-commit-config.yaml`,


### PR DESCRIPTION
- [x] create separate configs for the basic apps and the example app
- [x] add a rule for `.sh` files
- [x] update regex to disallow files names starting with a number or `.`. The files starting with a `.` are package config files and should just be ignored
