### PR TITLE
fix(nest): readme lint fix

### DIFF
--- a/src/templates/README.md.ejs
+++ b/src/templates/README.md.ejs
@@ -117,7 +117,8 @@ If you're on Apple M1, uncomment the `platform: linux/amd64` line:
 <% } -%>
 
 <% if (props.setup.openApi.nest) { -%>
-You can open the `docker-compose.override.yml` and addjust the volumes path for the databse.
+You can open the `docker-compose.override.yml` and addjust the volumes path
+for the databse.
 <% } -%>
 
 ### Provision the services
@@ -279,8 +280,9 @@ section at the bottom.
 <% if (props.setup.openApi.nest) { -%>
 ## Working with OpenAPI
 
-Swagger Document is being generated when the application is started so in order to see it you can navigate to
-`{HOST}:{PORT}/swagger` e.g. `http://localhost:3000/swagger` (make sure the app is running).
+Swagger Document is being generated when the application is started.
+In order to see it you can navigate to `{HOST}:{PORT}/swagger`
+e.g. `http://localhost:3000/swagger` (make sure the app is running).
 
 You can change the route if you want to in `main.ts`
 <% } -%>


### PR DESCRIPTION
When trying to commit `README.md` file in the example app there is a lint error which is being fixed with this PR